### PR TITLE
Refactor backend

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,24 +46,23 @@ def main(args):
     events = []
 
     analyze_enabled = not args['--nobackend']
-    nitro = Nitro(domain, analyze_enabled)
 
-    nitro.listener.set_traps(True)
-    for event in nitro.listen():
-        event_info = event.as_dict()
-        if analyze_enabled:
-            syscall = nitro.backend.process_event(event)
-            event_info = syscall.as_dict()
+    with Nitro(domain, analyze_enabled) as nitro:
+        nitro.listener.set_traps(True)
+        for event in nitro.listen():
+            event_info = event.as_dict()
+            if analyze_enabled:
+                syscall = nitro.backend.process_event(event)
+                event_info = syscall.as_dict()
 
-        if args['--stdout']:
-            pprint(event_info, width=1)
-        else:
-            events.append(event_info)
+            if args['--stdout']:
+                pprint(event_info, width=1)
+            else:
+                events.append(event_info)
 
-        # stop properly by CTRL+C
-        if not run:
-            break
-    nitro.listener.stop()
+            # stop properly by CTRL+C
+            if not run:
+                break
 
     if events:
         logging.info('Writing events')

--- a/nitro/backends/arguments.py
+++ b/nitro/backends/arguments.py
@@ -11,13 +11,11 @@ class ArgumentMap:
         "event",
         "name",
         "process",
-        "nitro",
         "modified"
     )
 
-    def __init__(self, event, name, process, nitro):
+    def __init__(self, event, name, process):
         self.event = event
         self.name = name
         self.process = process
-        self.nitro = nitro
         self.modified = {}

--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -54,11 +54,11 @@ class Backend:
                 self.stats['hooks_processed'] += 1
 
     def define_hook(self, name, callback, direction=SyscallDirection.enter):
-        logging.info('Defining hook on {}'.format(name))
+        logging.info('Defining hook on %s', name)
         self.hooks[direction][name] = callback
 
     def undefine_hook(self, name, direction=SyscallDirection.enter):
-        logging.info('Removing hook on {}'.format(name))
+        logging.info('Removing hook on %s', name)
         self.hooks[direction].pop(name)
 
     def __enter__(self):

--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -13,9 +13,8 @@ class Backend:
         "listener"
     )
 
-    def __init__(self, domain, listener, libvmi):
+    def __init__(self, domain, libvmi):
         self.domain = domain
-        self.listener = listener
         self.libvmi = libvmi
         self.hooks = {
             SyscallDirection.enter: {},
@@ -71,4 +70,3 @@ class Backend:
     def stop(self):
         logging.info(json.dumps(self.stats, indent=4))
         self.libvmi.destroy()
-        self.listener.stop()

--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -2,8 +2,6 @@ import logging
 import json
 from collections import defaultdict
 
-from nitro.nitro import Nitro
-from nitro.libvmi import Libvmi
 from nitro.event import SyscallDirection, SyscallType
 
 class Backend:
@@ -12,12 +10,12 @@ class Backend:
         "libvmi",
         "hooks",
         "stats",
-        "nitro"
+        "listener"
     )
 
-    def __init__(self, domain, libvmi):
+    def __init__(self, domain, listener, libvmi):
         self.domain = domain
-        self.nitro = Nitro(self.domain)
+        self.listener = listener
         self.libvmi = libvmi
         self.hooks = {
             SyscallDirection.enter: {},
@@ -73,4 +71,4 @@ class Backend:
     def stop(self):
         logging.info(json.dumps(self.stats, indent=4))
         self.libvmi.destroy()
-        self.nitro.stop()
+        self.listener.stop()

--- a/nitro/backends/factory.py
+++ b/nitro/backends/factory.py
@@ -19,3 +19,4 @@ def get_backend(domain):
     except KeyError:
         raise BackendNotFoundError('Unable to find an appropritate backend for'
                                    'this OS: {}'.format(os_type))
+    

--- a/nitro/backends/factory.py
+++ b/nitro/backends/factory.py
@@ -8,14 +8,15 @@ BACKENDS = {
     VMIOS.WINDOWS: WindowsBackend
 }
 
+def BackendNotFoundError(Exception):
+    pass
 
-def get_backend(domain, analyze):
+def get_backend(domain, listener):
     """Return backend based on libvmi configuration. If analyze if False, returns a dummy backend that does not analyze system calls. Returns None if the backend is missing"""
     libvmi = Libvmi(domain.name())
-    if analyze:
-        backend = BACKENDS.get(libvmi.get_ostype())
-        if backend is not None:
-            return backend(domain, libvmi)
-    else:
-        return Backend(domain, libvmi)
-
+    os_type = libvmi.get_ostype()
+    try:
+        return BACKENDS[os_type](domain, listener, libvmi)
+    except KeyError:
+        raise BackendNotFoundError('Unable to find an appropritate backend for'
+                                   'this OS: {}'.format(os_type))

--- a/nitro/backends/factory.py
+++ b/nitro/backends/factory.py
@@ -1,7 +1,6 @@
 from nitro.libvmi import VMIOS, Libvmi
 from nitro.backends.linux import LinuxBackend
 from nitro.backends.windows import WindowsBackend
-from nitro.backends.backend import Backend
 
 BACKENDS = {
     VMIOS.LINUX: LinuxBackend,
@@ -11,12 +10,12 @@ BACKENDS = {
 def BackendNotFoundError(Exception):
     pass
 
-def get_backend(domain, listener):
+def get_backend(domain):
     """Return backend based on libvmi configuration. If analyze if False, returns a dummy backend that does not analyze system calls. Returns None if the backend is missing"""
     libvmi = Libvmi(domain.name())
     os_type = libvmi.get_ostype()
     try:
-        return BACKENDS[os_type](domain, listener, libvmi)
+        return BACKENDS[os_type](domain, libvmi)
     except KeyError:
         raise BackendNotFoundError('Unable to find an appropritate backend for'
                                    'this OS: {}'.format(os_type))

--- a/nitro/backends/factory.py
+++ b/nitro/backends/factory.py
@@ -19,4 +19,3 @@ def get_backend(domain):
     except KeyError:
         raise BackendNotFoundError('Unable to find an appropritate backend for'
                                    'this OS: {}'.format(os_type))
-    

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -52,9 +52,9 @@ class LinuxBackend(Backend):
         else:
             name = self.get_syscall_name(event.regs.rax)
             self.syscall_stack[event.vcpu_nb].append(name)
-        args = LinuxArgumentMap(event, name, process, self.listener)
+        args = LinuxArgumentMap(event, name, process)
         cleaned = clean_name(name) if name is not None else None
-        syscall = Syscall(event, name, cleaned, process, self.listener, args)
+        syscall = Syscall(event, name, cleaned, process, args)
         self.dispatch_hooks(syscall)
         return syscall
 

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -26,8 +26,8 @@ class LinuxBackend(Backend):
         "name_offset"
     )
 
-    def __init__(self, domain, listener, libvmi):
-        super().__init__(domain, listener, libvmi)
+    def __init__(self, domain, libvmi):
+        super().__init__(domain, libvmi)
         self.sys_call_table_addr = self.libvmi.translate_ksym2v("sys_call_table")
         logging.debug("sys_call_table at {:f}".format(self.sys_call_table_addr))
 

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -29,7 +29,7 @@ class LinuxBackend(Backend):
     def __init__(self, domain, libvmi):
         super().__init__(domain, libvmi)
         self.sys_call_table_addr = self.libvmi.translate_ksym2v("sys_call_table")
-        logging.debug("sys_call_table at {:f}".format(self.sys_call_table_addr))
+        logging.debug("sys_call_table at %s", hex(self.sys_call_table_addr))
 
         vcpus_info = self.domain.vcpus()
         self.nb_vcpu = len(vcpus_info[0])

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -26,8 +26,8 @@ class LinuxBackend(Backend):
         "name_offset"
     )
 
-    def __init__(self, domain, libvmi):
-        super().__init__(domain, libvmi)
+    def __init__(self, domain, listener, libvmi):
+        super().__init__(domain, listener, libvmi)
         self.sys_call_table_addr = self.libvmi.translate_ksym2v("sys_call_table")
         logging.debug("sys_call_table at {:f}".format(self.sys_call_table_addr))
 
@@ -52,9 +52,9 @@ class LinuxBackend(Backend):
         else:
             name = self.get_syscall_name(event.regs.rax)
             self.syscall_stack[event.vcpu_nb].append(name)
-        args = LinuxArgumentMap(event, name, process, self.nitro)
+        args = LinuxArgumentMap(event, name, process, self.listener)
         cleaned = clean_name(name) if name is not None else None
-        syscall = Syscall(event, name, cleaned, process, self.nitro, args)
+        syscall = Syscall(event, name, cleaned, process, self.listener, args)
         self.dispatch_hooks(syscall)
         return syscall
 

--- a/nitro/backends/windows/arguments.py
+++ b/nitro/backends/windows/arguments.py
@@ -24,8 +24,8 @@ class WindowsArgumentMap(ArgumentMap):
         "arg_size_format",
     )
     
-    def __init__(self, event, name, process, nitro):
-        super().__init__(event, name, process, nitro)
+    def __init__(self, event, name, process):
+        super().__init__(event, name, process)
         self.arg_size_format = self.ARG_SIZE[self.event.type]
 
     def __getitem__(self, index):

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -25,8 +25,8 @@ class WindowsBackend(Backend):
         "processes"
     )
 
-    def __init__(self, domain, listener, libvmi):
-        super().__init__(domain, listener, libvmi)
+    def __init__(self, domain, libvmi):
+        super().__init__(domain, libvmi)
         vcpus_info = self.domain.vcpus()
         self.nb_vcpu = len(vcpus_info[0])
 

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -59,9 +59,9 @@ class WindowsBackend(Backend):
             syscall_name = self.get_syscall_name(event.regs.rax)
             # push them to the stack
             self.syscall_stack[event.vcpu_nb].append(syscall_name)
-        args = WindowsArgumentMap(event, syscall_name, process, self.listener)
+        args = WindowsArgumentMap(event, syscall_name, process)
         cleaned = clean_name(syscall_name)
-        syscall = Syscall(event, syscall_name, cleaned, process, self.listener, args)
+        syscall = Syscall(event, syscall_name, cleaned, process, args)
         # dispatch on the hooks
         self.dispatch_hooks(syscall)
         return syscall

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -25,9 +25,8 @@ class WindowsBackend(Backend):
         "processes"
     )
 
-    def __init__(self, domain, libvmi):
-        super().__init__(domain, libvmi)
-
+    def __init__(self, domain, listener, libvmi):
+        super().__init__(domain, listener, libvmi)
         vcpus_info = self.domain.vcpus()
         self.nb_vcpu = len(vcpus_info[0])
 
@@ -60,9 +59,9 @@ class WindowsBackend(Backend):
             syscall_name = self.get_syscall_name(event.regs.rax)
             # push them to the stack
             self.syscall_stack[event.vcpu_nb].append(syscall_name)
-        args = WindowsArgumentMap(event, syscall_name, process, self.nitro)
+        args = WindowsArgumentMap(event, syscall_name, process, self.listener)
         cleaned = clean_name(syscall_name)
-        syscall = Syscall(event, syscall_name, cleaned, process, self.nitro, args)
+        syscall = Syscall(event, syscall_name, cleaned, process, self.listener, args)
         # dispatch on the hooks
         self.dispatch_hooks(syscall)
         return syscall

--- a/nitro/backends/windows/types.py
+++ b/nitro/backends/windows/types.py
@@ -9,13 +9,13 @@ class WinStruct(object):
     _fields_ = []
 
     def __init__(self, addr, process):
-        # logging.debug('Building {} from {}'.format(self.__class__.__name__, hex(addr)))
+        # logging.debug('Building %s from %s', self.__class__.__name__, hex(addr))
         for f_offset, f_name, f_format in self._fields_:
-            # logging.debug('Field {}, {}, at {} + {}'.format(f_name, f_format, hex(addr), hex(f_offset)))
+            # logging.debug('Field %s, %s, at %s + %s', f_name, f_format, hex(addr), hex(f_offset))
             f_size = struct.calcsize(f_format)
             content = process.read_memory(addr + f_offset, f_size)
             f_value, *rest = struct.unpack(f_format, content)
-            # logging.debug('Value: {}'.format(hex(f_value)))
+            # logging.debug('Value: %s', hex(f_value))
             setattr(self, f_name, f_value)
 
 

--- a/nitro/kvm.py
+++ b/nitro/kvm.py
@@ -127,7 +127,7 @@ class KVM(IOCTL):
         self.fd = self.kvm_file.fileno()
 
     def attach_vm(self, pid):
-        logging.debug('attach_vm PID = {}'.format(pid))
+        logging.debug('attach_vm PID = %s', pid)
         c_pid = c_int(pid)
         r = self.make_ioctl(self.KVM_NITRO_ATTACH_VM, byref(c_pid))
         return r
@@ -153,7 +153,7 @@ class VM(IOCTL):
         return vcpus
 
     def set_syscall_trap(self, enabled):
-        logging.debug('set_syscall_trap {}'.format(enabled))
+        logging.debug('set_syscall_trap %s', enabled)
         c_enabled = c_bool(enabled)
         r = self.make_ioctl(self.KVM_NITRO_SET_SYSCALL_TRAP, byref(c_enabled))
         return r
@@ -178,7 +178,7 @@ class VCPU(IOCTL):
         self.fd = vcpu_fd
 
     def get_event(self):
-        # logging.debug('get_event {}'.format(self.vcpu_nb))
+        # logging.debug('get_event %s, self.vcpu_nb)
         nitro_ev = NitroEventStr()
         ret = self.make_ioctl(self.KVM_NITRO_GET_EVENT, byref(nitro_ev))
         if ret != 0:
@@ -186,7 +186,7 @@ class VCPU(IOCTL):
         return nitro_ev
 
     def continue_vm(self):
-        # logging.debug('continue_vm {}'.format(self.vcpu_nb))
+        # logging.debug('continue_vm %s', self.vcpu_nb)
         return self.make_ioctl(self.KVM_NITRO_CONTINUE, 0)
 
     def get_regs(self):

--- a/nitro/libvmi.py
+++ b/nitro/libvmi.py
@@ -127,7 +127,7 @@ class Libvmi:
         if ptr:
             return cast(ptr, c_char_p).value.decode('utf-8')
         else:
-            logging.debug("Failed to find symbol associated with virtual address: {}".format(vaddr))
+            logging.debug("Failed to find symbol associated with virtual address: %s", vaddr)
 
     def translate_kv2p(self, vaddr):
         return self.libvmi.vmi_translate_kv2p(self.vmi, c_uint64(vaddr))
@@ -137,7 +137,7 @@ class Libvmi:
         value_c = c_ulonglong()
         status = self.libvmi.vmi_read_addr_ksym(self.vmi, symbol_c, byref(value_c))
         if status == VMI_FAILURE:
-            logging.debug('VMI_FAILURE trying to read {}, with {}'.format(symbol, 'read_addr_ksym'))
+            logging.debug('VMI_FAILURE trying to read %s, with %s', symbol, 'read_addr_ksym')
             raise LibvmiError('VMI_FAILURE')
 
         return value_c.value
@@ -158,7 +158,7 @@ class Libvmi:
         value_c = c_ulonglong()
         status = self.libvmi.vmi_read_addr_va(self.vmi, vaddr_c, pid_c, byref(value_c))
         if status == VMI_FAILURE:
-            logging.debug('VMI_FAILURE trying to read {}, with {}'.format(hex(vaddr), 'read_addr_va'))
+            logging.debug('VMI_FAILURE trying to read %s, with %s', hex(vaddr), 'read_addr_va')
             raise LibvmiError('VMI_FAILURE')
         return value_c.value
 
@@ -179,7 +179,7 @@ class Libvmi:
         buffer = (c_char * count)()
         nb_read = self.libvmi.vmi_read_va(self.vmi, vaddr_c, pid_c, byref(buffer), count)
         if nb_read == 0:
-            logging.debug('VMI_FAILURE trying to read {}, with {}'.format(hex(vaddr), 'read_va'))
+            logging.debug('VMI_FAILURE trying to read %s, with %s', hex(vaddr), 'read_va')
             raise LibvmiError('VMI_FAILURE')
         value = bytes(buffer)[:nb_read]
         return value
@@ -194,7 +194,7 @@ class Libvmi:
         buffer_c = create_string_buffer(buffer)
         nb_written = self.libvmi.vmi_write_va(self.vmi, vaddr_c, pid_c, buffer_c, count_c)
         if nb_written == 0 or nb_written != count:
-            logging.debug('VMI_FAILURE trying to write {}, with {}'.format(hex(vaddr), 'write_va'))
+            logging.debug('VMI_FAILURE trying to write %s, with %s', hex(vaddr), 'write_va')
             raise LibvmiError('VMI_FAILURE')
         return nb_written
 
@@ -205,7 +205,7 @@ class Libvmi:
             return result.value
         else:
             self.failures += 1
-            logging.debug('VMI_FAILURE trying to read_32 at 0x{:x} with pid {}'.format(vaddr, pid))
+            logging.debug('VMI_FAILURE trying to read_32 at %s with pid %s', hex(vaddr), pid)
             raise LibvmiError('VMI_FAILURE')
 
     def v2pcache_flush(self, dtb=0):

--- a/nitro/listener.py
+++ b/nitro/listener.py
@@ -35,7 +35,7 @@ def find_qemu_pid(vm_name):
             raise e
 
 
-class Nitro:
+class Listener:
 
     __slots__ = (
         'domain',

--- a/nitro/listener.py
+++ b/nitro/listener.py
@@ -31,7 +31,7 @@ def find_qemu_pid(vm_name):
             return pid
         except ValueError as e:
             # output issue
-            logging.critical('Cannot find PID with pgrep output: {}'.format(output))
+            logging.critical('Cannot find PID with pgrep output: %s', output)
             raise e
 
 
@@ -59,7 +59,7 @@ class Listener:
         self.vm_io = VM(vm_fd)
         # get VCPU fds
         self.vcpus_io = self.vm_io.attach_vcpus()
-        logging.info('Detected {} VCPUs'.format(len(self.vcpus_io)))
+        logging.info('Detected %s VCPUs', len(self.vcpus_io))
         self.stop_request = None
         self.futures = None
         self.queue = None
@@ -113,7 +113,7 @@ class Listener:
         logging.info('Stop Nitro listening')
 
     def listen_vcpu(self, vcpu_io, queue):
-        logging.info('Start listening on VCPU {}'.format(vcpu_io.vcpu_nb))
+        logging.info('Start listening on VCPU %s', vcpu_io.vcpu_nb)
         # we need a per thread continue event
         continue_event = threading.Event()
         while not self.stop_request.is_set():
@@ -132,7 +132,7 @@ class Listener:
                 continue_event.clear()
                 vcpu_io.continue_vm()
 
-        logging.debug('stop listening on VCPU {}'.format(vcpu_io.vcpu_nb))
+        logging.debug('stop listening on VCPU %s', vcpu_io.vcpu_nb)
 
     def stop_listen(self):
         self.set_traps(False)

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -6,6 +6,7 @@ class Nitro:
     def __init__(self, domain, introspection=True):
         self.listener = Listener(domain)
         self.introspection = introspection
+        self.backend = None
         if self.introspection:
             self.backend = get_backend(domain)
 
@@ -16,6 +17,6 @@ class Nitro:
         return self
 
     def __exit__(self, type, value, traceback):
-        if self.introspection:
+        if self.backend is not None:
             self.backend.stop()
         self.listener.stop()

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -7,7 +7,15 @@ class Nitro:
         self.listener = Listener(domain)
         self.introspection = introspection
         if self.introspection:
-            self.backend = get_backend(domain, self.listener)
+            self.backend = get_backend(domain)
 
     def listen(self):
         yield from self.listener.listen()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.introspection:
+            self.backend.stop()
+        self.listener.stop()

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -1,0 +1,13 @@
+from nitro.listener import Listener
+from nitro.backends import get_backend
+
+class Nitro:
+
+    def __init__(self, domain, introspection=True):
+        self.listener = Listener(domain)
+        self.introspection = introspection
+        if self.introspection:
+            self.backend = get_backend(domain, self.listener)
+
+    def listen(self):
+        yield from self.listener.listen()

--- a/nitro/syscall.py
+++ b/nitro/syscall.py
@@ -7,17 +7,15 @@ class Syscall:
         "full_name",
         "name",
         "process",
-        "nitro",
         "args",
         "hook"
     )
 
-    def __init__(self, event, full_name, name, process, nitro, args):
+    def __init__(self, event, full_name, name, process, args):
         self.event = event
         self.full_name = full_name
         self.name = name
         self.process = process
-        self.nitro = nitro
         self.args = args
         self.hook = None
 


### PR DESCRIPTION
This is a an experiment to developer a better API than our so called "`Backend`".

I wanted to abstract the `get_backend` method, and hide it, and i wanted to use the `Nitro` name for the main nitro API.

So i renamed  `nitro.py` to `listener.py`
I created a new class `Nitro` which contains the vcpu `listener` and the `backend`.

Therefore, we can now have this API
~~~Python
nitro = Nitro(domain)
nitro.listener.set_traps(True)
for event in nitro.listen()
     nitro.backend.process_event(event)
~~~


Introspection is enabled by default, but you can disable it.
~~~Python
nitro = Nitro(domain, False)
~~~

This is just a draft for a new API.

What do you think @Soft ? :)