### PR TITLE
Refactor windows process

### DIFF
--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -5,7 +5,7 @@ from ctypes import sizeof, c_void_p
 
 from nitro.syscall import Syscall
 from nitro.event import SyscallDirection
-from nitro.process import Process
+from nitro.backends.process import Process
 from nitro.backends.backend import Backend
 from nitro.backends.linux.arguments import LinuxArgumentMap
 

--- a/nitro/backends/process.py
+++ b/nitro/backends/process.py
@@ -1,12 +1,15 @@
-
 class Process:
 
-    def __init__(self, cr3, descriptor, name, pid, libvmi):
+    __slots__ = (
+        "libvmi",
+        "cr3",
+        "descriptor",
+    )
+
+    def __init__(self, libvmi, cr3, descriptor):
+        self.libvmi = libvmi
         self.cr3 = cr3
         self.descriptor = descriptor
-        self.name = name
-        self.pid = pid
-        self.libvmi = libvmi
 
     def as_dict(self):
         info = {

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from nitro.event import SyscallDirection, SyscallType
 from nitro.syscall import Syscall
-from nitro.process import Process
+from nitro.backends.windows.process import WindowsProcess
 from nitro.backends.backend import Backend
 from nitro.backends.windows.arguments import WindowsArgumentMap
 
@@ -133,15 +133,7 @@ class WindowsBackend(Backend):
             directory_table_base = self.libvmi.read_addr_va(directory_table_base_off, 0)
             # compare to our cr3
             if cr3 == directory_table_base:
-                # get name
-                image_file_name_off = start_eproc + self.libvmi.get_offset('win_pname')
-                image_file_name = self.libvmi.read_str_va(image_file_name_off, 0)
-                # get pid
-                unique_processid_off = start_eproc + self.libvmi.get_offset('win_pid')
-                pid = self.libvmi.read_addr_va(unique_processid_off, 0)
-                eprocess = Process(cr3, start_eproc, image_file_name, pid, self.libvmi)
-                return eprocess
-
+                return WindowsProcess(self.libvmi, cr3, start_eproc)
             # read new flink
             flink = self.libvmi.read_addr_va(flink, 0)
         raise RuntimeError('Process not found')

--- a/nitro/backends/windows/process.py
+++ b/nitro/backends/windows/process.py
@@ -1,0 +1,18 @@
+from nitro.backends.process import Process
+
+class WindowsProcess(Process):
+
+    __slots__ = (
+        "name",
+        "pid",
+    )
+
+    # descriptor is the start address of the EPROCESS struct
+    def __init__(self, libvmi, cr3, descriptor):
+        super().__init__(libvmi, cr3, descriptor)
+        # get name
+        image_file_name_off = self.descriptor + self.libvmi.get_offset('win_pname')
+        self.name = self.libvmi.read_str_va(image_file_name_off, 0)
+        # get pid
+        unique_processid_off = self.descriptor + self.libvmi.get_offset('win_pid')
+        self.pid = self.libvmi.read_addr_va(unique_processid_off, 0)


### PR DESCRIPTION
Refactoring of the `Process` class, which has been moved to `backends/`.

Created a `WindowsProcess` class to contain Windows specific EPROCESS parsing logic, moving away from `windows/backend.py`.

Note: Linux backend is broken with this PR.

You could  later update the main Linux PR on kvm-vmi/nitro with an refactored `LinuxProcess` class.